### PR TITLE
import importlib from directly from python

### DIFF
--- a/thumbnails/utils.py
+++ b/thumbnails/utils.py
@@ -1,6 +1,10 @@
 from copy import deepcopy
 
-from django.utils import importlib
+try:
+    import importlib
+except:
+    # for python < 2.7.5
+    from django.utils import importlib
 
 
 def import_attribute(name):


### PR DESCRIPTION
django.utils.importlib is deprecated and will be removed in django 1.9

This is to remove deprecation warning everytime I run django dev server.