### PR TITLE
Fix Source.DoesNotExist after migrating ImageField

### DIFF
--- a/thumbnails/backends/metadata.py
+++ b/thumbnails/backends/metadata.py
@@ -76,7 +76,12 @@ class DatabaseBackend(BaseBackend):
             return None
 
     def add_thumbnail(self, source_name, size, name):
-        source = self.get_source(source_name)
+        try:
+            source = self.get_source(source_name)
+        except Source.DoesNotExist:
+            # If the source doesn't exist, create it
+            # For example when migrating from a regular ImageField to a thumbnailed ImageField
+            source = self.add_source(source_name)
         meta = ThumbnailMeta.objects.create(source=source, size=size, name=name)
         return ImageMeta(source_name, meta.name, meta.size)
 


### PR DESCRIPTION
When migrating from a regular ImageField to this thumbnailed ImageField with a database backend, the thumbnails.Source table will be empty. When querying for thumbnails for these images, this will result in a Source.DoesNotExist exception, because indeed no thumbnail source exists. 

This PR adds a minor fix for this, enabling easy migrations: whenever the ThumbnailManager tries to generate a thumbnail for a file for which no thumbnail Source exists in the database backend, it simply creates one.