### PR TITLE
Replace imghdr.what with PIL.Image.format

### DIFF
--- a/thumbnails/post_processors.py
+++ b/thumbnails/post_processors.py
@@ -1,4 +1,4 @@
-import imghdr
+from PIL import Image
 import os
 from subprocess import call
 import tempfile
@@ -57,7 +57,7 @@ def optimize(thumbnail_file, jpg_command=None, png_command=None,
     f.close()
 
     # Detect filetype
-    filetype = imghdr.what(thumbnail_filename)
+    filetype = Image.open(thumbnail_filename).format
 
     # Construct command to optimize image based on filetype
     command = None

--- a/thumbnails/post_processors.py
+++ b/thumbnails/post_processors.py
@@ -57,7 +57,7 @@ def optimize(thumbnail_file, jpg_command=None, png_command=None,
     f.close()
 
     # Detect filetype
-    filetype = Image.open(thumbnail_filename).format
+    filetype = Image.open(thumbnail_filename).format.lower()
 
     # Construct command to optimize image based on filetype
     command = None


### PR DESCRIPTION
Fixes GH-125

[imghdr is deprecated in python-3.13](https://peps.python.org/pep-0594/#imghdr)

I haven't tested this exhaustively but I think this is all that needs to be done.