### PR TITLE
Don't discard the result of post-processing

### DIFF
--- a/thumbnails/post_processors.py
+++ b/thumbnails/post_processors.py
@@ -23,7 +23,9 @@ def process(thumbnail_file, size, **kwargs):
 
     size_dict = conf.SIZES[size]
     for processor in size_dict['POST_PROCESSORS']:
-        processor['processor'](thumbnail_file, **processor['kwargs'])
+        thumbnail_file = processor['processor'](
+            thumbnail_file, **processor['kwargs']
+        )
 
     return thumbnail_file
 


### PR DESCRIPTION
Hey. Currently, the results of post-processing is discarded, because the file objects returned by postprocessor functions aren't saved anywhere (so no optimization, no nothing). This PR fixes it.